### PR TITLE
Serialize the flatpak repo pushes in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -302,6 +302,9 @@ jobs:
   release_nightly:
     if: github.ref == 'refs/heads/main' && needs.detect-changes.outputs.build-relevant == 'true'
     runs-on: ubuntu-22.04
+    concurrency:
+      group: flatpak-push
+      cancel-in-progress: false
     needs:
       - detect-changes
       - build-macos
@@ -358,6 +361,9 @@ jobs:
   release:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-22.04
+    concurrency:
+      group: flatpak-push
+      cancel-in-progress: false
     needs:
       - build-macos
       - package-linux-deb


### PR DESCRIPTION
The `release` (tag) and `release_nightly` (main) jobs both check out `jpjonte/flatpak` at job start and push to its `main` roughly fourteen minutes later via `git-auto-commit-action` (which runs with `skip_fetch: true`). Nothing serialized them, so pushing `main` and a release tag close together made both runs race, and the second push was rejected non-fast-forward against its stale checkout.

This bit the 0.16.0 release: the nightly pushed at 17:14:36Z, the stable push failed at 17:14:44Z, and the `release` job died **before** `ncipollo/release-action` — so no GitHub release was created while every build job reported green. Re-running the failed job published it.

0.15.1 did not avoid this. Its concurrent main run failed at `test` (the `rewind_cadence` flake, since fixed in `437d0f4`), so `release_nightly` never reached its push. The race has been latent since nightly flatpak publishing was added.

A shared job-level concurrency group makes the second job wait before it *starts*, so its checkout happens after the other job has pushed. Serializing only the push step would not work — the losing job would still hold a stale checkout.

Note the one trade-off: GitHub cancels a *pending* job in a concurrency group when a third run enters it. That needs a main push landing while a release is already queued behind a nightly; the failure would be a visibly cancelled job, recoverable with `gh run rerun --failed`. The alternative — replacing `git-auto-commit-action` with a hand-rolled fetch/rebase/push-retry loop — avoids that but is considerably more moving parts in the release path.

Verified: the workflow parses, all 14 jobs intact, both groups attached to the right jobs. Full behaviour can only be confirmed by the next release.